### PR TITLE
Always make reset pin an open-drain output. Fixes #4.

### DIFF
--- a/hs-probe-bsp/src/gpio.rs
+++ b/hs-probe-bsp/src/gpio.rs
@@ -379,12 +379,12 @@ impl<'a> Pins<'a> {
             .set_ospeed_low()
             .set_mode_output();
 
-        // Open-drain output to RESET reset line (active low). Starts high-impedance.
+        // Open-drain output to RESET reset line (active low).
         self.reset
             .set_high()
             .set_otype_opendrain()
             .set_ospeed_high()
-            .set_mode_input();
+            .set_mode_output();
 
         // Input for GNDDetect
         self.gnd_detect
@@ -460,7 +460,7 @@ impl<'a> Pins<'a> {
 
     /// Place SPI pins into high-impedance mode
     pub fn high_impedance_mode(&self) {
-        self.reset.set_mode_input();
+        self.reset.set_high().set_mode_output();
         self.usart1_rx.set_mode_input();
         self.spi1_clk.set_mode_input();
         self.spi1_miso.set_mode_input();


### PR DESCRIPTION
This is one potential fix, otherwise we could also leave it in input mode most of the time but swap to output when we get a DAP_SWJ_Pins command to drive it low.

Since it's always in open-drain mode and starts high, the effect is the same. To enter 'high-impedance' mode we just drive it high again.