### PR TITLE
Fix spurious JTAG clock cycles after SPI DMA completes.

### DIFF
--- a/firmware/src/jtag.rs
+++ b/firmware/src/jtag.rs
@@ -171,7 +171,11 @@ impl<'a> JTAG<'a> {
                 if capture != 0 {
                     rxidx += buffer_idx;
                 }
+                // Set TDI GPIO to the last bit the SPI peripheral transmitted,
+                // to prevent it changing state when we set it to an output.
+                self.pins.tdi.set_bool((buffer[buffer_idx - 1] >> 7) != 0);
                 self.bitbang_mode();
+                self.spi.disable();
             }
         }
 

--- a/hs-probe-bsp/src/spi.rs
+++ b/hs-probe-bsp/src/spi.rs
@@ -137,7 +137,7 @@ impl SPI {
     /// Wait for any pending operation then disable SPI
     pub fn disable(&self) {
         self.wait_busy();
-        write_reg!(spi, self.spi, CR1, SPE: Disabled);
+        modify_reg!(spi, self.spi, CR1, SPE: Disabled);
     }
 
     /// Transmit `txdata` and write the same number of bytes into `rxdata`.
@@ -153,9 +153,8 @@ impl SPI {
         // Busy wait for RX DMA completion (at most 43µs)
         while dma.spi2_busy() {}
 
-        // Disable SPI and DMA
+        // Disable DMA
         dma.spi2_disable();
-        modify_reg!(spi, self.spi, CR1, SPE: Disabled);
     }
 
     /// Transmit 4 bits


### PR DESCRIPTION
Before this change, disabling SPI2 after each DMA exchange while the JTAG pins were still set as alternate outputs led to the pins floating, which could lead to TCK becoming set before being driven low once the JTAG code swaps the pins back to GPIO mode, which inserted an extra clock cycle.

Now, the SPI is only disabled after the pins are swapped back to GPIO.

Additionally, set the TDI pin state to the last bit the SPI controller was transmitting to prevent it reverting to the last state it was manually set to when we return it to being an output.