### PR TITLE
README: Document the need for cargo-binutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ cargo build --release
 
 ## Loading the firmware
 
-The HS-Probe supports `dfu-util` and can have its firmware loaded via it. To generate the bin, run:
+The HS-Probe supports `dfu-util` and can have its firmware loaded via it. To
+generate the bin, install
+[cargo-binutils](https://github.com/rust-embedded/cargo-binutils) and run:
 
 ```console
 cargo objcopy --release -- -O binary firmware.bin


### PR DESCRIPTION
I initially tried `cargo install cargo-objcopy` which didn't work...