### PR TITLE
Disable red and green LEDs and T5V_EN when in Suspend

### DIFF
--- a/firmware/src/app.rs
+++ b/firmware/src/app.rs
@@ -118,8 +118,11 @@ impl<'a> App<'a> {
             }
             Request::Suspend => {
                 self.pins.high_impedance_mode();
+                self.pins.led_red.set_high();
                 self.pins.led_blue.set_high();
+                self.pins.led_green.set_high();
                 self.pins.tvcc_en.set_low();
+                self.pins.t5v_en.set_low();
                 self.swd_spi.disable();
                 self.jtag_spi.disable();
             }


### PR DESCRIPTION
We should go to the lowest power usage here (ideally/per-sec, not more than 2.5mA) so we should turn off all the LEDs and ensure all target power is disabled.

For some reason it seems like this code is getting called a second after first connection on Linux, and now you notice because the red LED turns off. It turns back on whenever you attempt to use the probe and stays on afterwards, though. I guess the host USB stack is just doing a suspend and resume as part of its initialisation or something. 