### PR TITLE
Fix SWO baud rate computation and DMA configuration

### DIFF
--- a/firmware/src/app.rs
+++ b/firmware/src/app.rs
@@ -71,6 +71,9 @@ impl<'a> App<'a> {
         self.jtag_spi.set_base_clock(&clocks);
         self.jtag_spi.disable();
 
+        // Configure DAP timing information
+        self.dap.setup(&clocks);
+
         // Configure USB peripheral and connect to host
         self.usb.setup(&clocks, serial);
 

--- a/firmware/src/dap.rs
+++ b/firmware/src/dap.rs
@@ -2,7 +2,7 @@
 // Dual licensed under the Apache 2.0 and MIT licenses.
 
 use crate::{
-    bsp::{gpio::Pins, uart::UART},
+    bsp::{gpio::Pins, uart::UART, rcc::Clocks},
     jtag, swd, DAP1_PACKET_SIZE, DAP2_PACKET_SIZE,
 };
 use core::convert::{TryFrom, TryInto};
@@ -270,6 +270,13 @@ impl<'a> DAP<'a> {
             swo_streaming: false,
             match_retries: 5,
         }
+    }
+
+    /// Call with the system clock speeds to configure peripherals that require timing information.
+    ///
+    /// Currently this only configures the SWO USART baud rate calculation.
+    pub fn setup(&mut self, clocks: &Clocks) {
+        self.uart.setup(clocks);
     }
 
     /// Process a new CMSIS-DAP command from `report`.

--- a/hs-probe-bsp/src/dma.rs
+++ b/hs-probe-bsp/src/dma.rs
@@ -272,9 +272,9 @@ impl DMA {
             CDMEIF5: Clear,
             CFEIF5: Clear
         );
-        write_reg!(dma, self.dma1, NDTR5, rx.len() as u32);
-        write_reg!(dma, self.dma1, M0AR5, rx.as_mut_ptr() as u32);
-        modify_reg!(dma, self.dma1, CR5, EN: Enabled);
+        write_reg!(dma, self.dma2, NDTR5, rx.len() as u32);
+        write_reg!(dma, self.dma2, M0AR5, rx.as_mut_ptr() as u32);
+        modify_reg!(dma, self.dma2, CR5, EN: Enabled);
     }
 
     /// Return how many bytes are left to transfer for USART1

--- a/hs-probe-bsp/src/uart.rs
+++ b/hs-probe-bsp/src/uart.rs
@@ -60,7 +60,7 @@ impl<'a> UART<'a> {
     /// Request a target baud rate. Returns actual baud rate set.
     pub fn set_baud(&self, baud: u32) -> u32 {
         // Find closest divider which is also an even integer >= 16
-        let mut div = 96_000_000 / baud;
+        let mut div = 144_000_000 / baud;
         div &= 0xffff_fffe;
         if div < 16 {
             div = 16;
@@ -71,7 +71,7 @@ impl<'a> UART<'a> {
         write_reg!(usart, self.uart, BRR, brr);
 
         // Return actual baud rate
-        96_000_000 / div
+        144_000_000 / div
     }
 
     /// Fetch current number of bytes available.


### PR DESCRIPTION
It turns out SWO wasn't working on hs-probe for two reasons:

* Wrong baud rate computation, assumed 48MHz CPU clock
* Incorrect DMA peripheral used when configuring USART1, was DMA1 but should be DMA2

This PR fixes both issues, tested on my hs-probe which can now receive SWO data at 1MBd. I haven't done more extensive testing but I guess no-one else did either...