### PR TITLE
SWJ_Sequence command uses SWD related pins when SWD mode is expected

### DIFF
--- a/firmware/src/dap.rs
+++ b/firmware/src/dap.rs
@@ -564,11 +564,7 @@ impl<'a> DAP<'a> {
 
         match self.mode {
             Some(DAPMode::SWD) => {
-                // Ensure SWD pins are in the right mode, in case they've been used as outputs
-                // by the SWJ_Pins command.
-                self.pins.swd_clk_spi();
-                self.pins.swd_tx();
-                self.swd.tx_sequence(seq);
+                self.swd.tx_sequence(seq, nbits);
             }
             Some(DAPMode::JTAG) => {
                 self.jtag.tms_sequence(seq, nbits);

--- a/firmware/src/dap.rs
+++ b/firmware/src/dap.rs
@@ -564,9 +564,7 @@ impl<'a> DAP<'a> {
 
         match self.mode {
             Some(DAPMode::SWD) => {
-                self.pins.jtag_mode();
-                self.jtag.tms_sequence(seq, nbits);
-                self.pins.swd_mode();
+                self.swd.tx_sequence(seq);
             }
             Some(DAPMode::JTAG) => {
                 self.jtag.tms_sequence(seq, nbits);

--- a/firmware/src/dap.rs
+++ b/firmware/src/dap.rs
@@ -564,6 +564,10 @@ impl<'a> DAP<'a> {
 
         match self.mode {
             Some(DAPMode::SWD) => {
+                // Ensure SWD pins are in the right mode, in case they've been used as outputs
+                // by the SWJ_Pins command.
+                self.pins.swd_clk_spi();
+                self.pins.swd_tx();
                 self.swd.tx_sequence(seq);
             }
             Some(DAPMode::JTAG) => {

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> ! {
     let syst = stm32ral::syst::SYST::take().unwrap();
     let delay = bsp::delay::Delay::new(syst);
 
-    let swd = swd::SWD::new(&spi1, &pins);
+    let swd = swd::SWD::new(&spi1, &pins, &delay);
     let jtag = jtag::JTAG::new(&spi2, &dma, &pins, &delay);
     let mut dap = dap::DAP::new(swd, jtag, &mut uart1, &pins);
 

--- a/firmware/src/swd.rs
+++ b/firmware/src/swd.rs
@@ -106,6 +106,14 @@ impl<'a> SWD<'a> {
         self.wait_retries = wait_retries;
     }
 
+    pub fn tx_sequence(&self, sequence: &[u8]) {
+        self.pins.swd_tx();
+        for byte in sequence {
+            self.spi.tx8(*byte);
+        }
+        self.spi.wait_busy();
+    }
+
     pub fn idle_low(&self) {
         self.spi.tx4(0x0);
     }

--- a/hs-probe-bsp/src/gpio.rs
+++ b/hs-probe-bsp/src/gpio.rs
@@ -591,10 +591,16 @@ impl<'a> Pins<'a> {
         self.spi1_mosi.set_mode_input();
     }
 
-    /// Connect SPI1_MOSI to SWDIO, we drive the bus
+    /// Connect SPI1_MOSI to SWDIO, SPI drives the bus
     #[inline]
     pub fn swd_tx(&self) {
         self.spi1_mosi.set_mode_alternate();
+    }
+
+    /// Connect SPI1_MOSI to SWDIO, manual bitbanging
+    #[inline]
+    pub fn swd_tx_direct(&self) {
+        self.spi1_mosi.set_mode_output();
     }
 
     /// Swap SPI1_CLK pin to direct output mode for manual driving


### PR DESCRIPTION
@adamgreig @Disasm 

This change is a NOOP for most users as `SPI{1,2}_CLK` lines are shorted together in a reference HS-Probe programmer. Unfortunately in a custom PCB setup that we've built, SPI2 related GPIOs are left disconnected as they were incorrectly assumed to be used in JTAG configuration only and irrelevant for SWD based communication. 

